### PR TITLE
Removed the commented line display module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Quick start
 
 PyPastry requires python 3.5 or greater.
 
-    > pip install pypastry
+    > pip install pypastry==0.0.1.dev1
 	> pastry init pastry-test
     > cd pastry-test
     > pastry run -m "First experiment"

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -57,5 +57,4 @@ def print_cache_file(limit = False):
             limit = len(read_list)-3
         print(read_list[0])
         print("\n".join(read_list[-(2+limit):-2]))
-        #print(f'Cache provides:\n{read_list[-1]}')
         print('Cache provides: \n {}'.format(read_list[-1]))


### PR DESCRIPTION
The commented line had f string code which doesn't work for python 3.5 