### PR TITLE
Remove automatic commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Quick start
 
 PyPastry requires python 3.5 or greater.
 
-    > pip install pypastry==0.0.1.dev1
+    > pip install pypastry==0.2.0
 	> pastry init pastry-test
     > cd pastry-test
     > pastry run -m "First experiment"
@@ -55,12 +55,12 @@ When you type `pastry run`, PyPastry does this:
  - For each train and test set, it trains the `predictor` on the train set and generate predictions
    on the test set, and computes the score on the test set using the `scorer`.
  - Generates a results file in JSON format and stores it in a folder called `results`
- - Adds the new file and any modified files to git staging and runs a git commit.
  - Outputs the results of the experiment.
+ - Your repo has to be clean (no (un)staged changes) for experiment to run. If you want to use dirty repo, you can with calling pypsatry with force flag `-f`. However, results will not be possible to bond with exact code state.
 
 The results includes:
- - Git hash: the commit identifier from git that allows you to return to this version of the code
-   at any later point in time.
+ - Git hash: the commit identifier of the code used to run the experiment. There might be `"dirty_"` prefix indicating that unclean repo was used with this experiment. The hash belongs to the latest commit, however, the information about (un)staged changes is lost.
+ - Git summary: A summary note
  - Dataset hash: a hash generated from the dataset that will change if the dataset changes.
  - Run start: the time that the experiment run started
  - Model: the name of the `predictor` class used

--- a/pypastry/commands/init.py
+++ b/pypastry/commands/init.py
@@ -1,9 +1,6 @@
 import argparse
 import sys
 from os import path, mkdir, chdir
-from shutil import copyfile
-
-from git import Repo
 
 
 def run():
@@ -20,10 +17,3 @@ def run():
         pass
 
     chdir(directory)
-
-    repo = Repo.init('.')  # type:  git.repo.base.Repo
-    for filename in ['pie.py', '.gitignore']:
-        source_file_path = path.join(path.dirname(__file__), '..', '..', 'data', filename)
-        copyfile(source_file_path, filename)
-        repo.index.add([filename])
-

--- a/pypastry/commands/print_.py
+++ b/pypastry/commands/print_.py
@@ -1,7 +1,4 @@
 import argparse
-import sys
-
-import git
 
 from pypastry.display import print_cache_file, cache_display, _get_results_dataframe
 from pypastry.paths import RESULTS_PATH
@@ -13,17 +10,16 @@ def run():
     parser.add_argument('-e', '--export', type=str, required=False, help='File to output the results in CSV format')
 
     args = parser.parse_args(sys.argv[2:])
-    repo = git.Repo(search_parent_directories=True)
     if args.export is not None:
         results = get_results()
-        results_dataframe = _get_results_dataframe(results, repo.head.object.hexsha)
+        results_dataframe = _get_results_dataframe(results)
         results_dataframe.to_csv(args.export)
         return
     try:
         print_cache_file(args.limit)
     except FileNotFoundError:
         results = get_results()
-        cache_display(results, repo.head.object.hexsha)
+        cache_display(results)
         print_cache_file(args.limit)
 
 

--- a/pypastry/commands/print_.py
+++ b/pypastry/commands/print_.py
@@ -1,6 +1,8 @@
 import argparse
 import sys
 
+import git
+
 from pypastry.display import print_cache_file, cache_display, _get_results_dataframe
 from pypastry.paths import RESULTS_PATH
 
@@ -11,16 +13,17 @@ def run():
     parser.add_argument('-e', '--export', type=str, required=False, help='File to output the results in CSV format')
 
     args = parser.parse_args(sys.argv[2:])
+    repo = git.Repo(search_parent_directories=True)
     if args.export is not None:
         results = get_results()
-        results_dataframe = _get_results_dataframe(results)
+        results_dataframe = _get_results_dataframe(results, repo.head.object.hexsha)
         results_dataframe.to_csv(args.export)
         return
     try:
         print_cache_file(args.limit)
     except FileNotFoundError:
         results = get_results()
-        cache_display(results)
+        cache_display(results, repo.head.object.hexsha)
         print_cache_file(args.limit)
 
 

--- a/pypastry/commands/run.py
+++ b/pypastry/commands/run.py
@@ -6,6 +6,7 @@ from pypastry.experiment.evaluation import run_experiment
 
 def run():
     parser = argparse.ArgumentParser(prog='pastry run')
+    parser.add_argument('-m', '--message', required=True, type=str, help='Summary message about the experiment.')
     parser.add_argument('-f', '--force', action='store_true', help='Force a re-run of the experiment')
 
     args = parser.parse_args(sys.argv[2:])
@@ -14,5 +15,6 @@ def run():
     import pie
     experiment = pie.get_experiment()
     force = args.force
+    message = args.message
 
-    run_experiment(experiment, force)
+    run_experiment(experiment, message, force)

--- a/pypastry/commands/run.py
+++ b/pypastry/commands/run.py
@@ -6,7 +6,7 @@ from pypastry.experiment.evaluation import run_experiment
 
 def run():
     parser = argparse.ArgumentParser(prog='pastry run')
-    parser.add_argument('-m', '--message', required=True, type=str, help='Summary message about the experiment.')
+    parser.add_argument('-m', '--message', default="", type=str, help='Summary message about the experiment.')
     parser.add_argument('-f', '--force', action='store_true', help='Force a re-run of the experiment')
 
     args = parser.parse_args(sys.argv[2:])

--- a/pypastry/commands/run.py
+++ b/pypastry/commands/run.py
@@ -7,7 +7,6 @@ from pypastry.experiment.evaluation import run_experiment
 def run():
     parser = argparse.ArgumentParser(prog='pastry run')
     parser.add_argument('-f', '--force', action='store_true', help='Force a re-run of the experiment')
-    parser.add_argument('-m', '--message', type=str, required=True, help='Git commit message')
 
     args = parser.parse_args(sys.argv[2:])
 
@@ -15,6 +14,5 @@ def run():
     import pie
     experiment = pie.get_experiment()
     force = args.force
-    message = args.message
 
-    run_experiment(experiment, message, force)
+    run_experiment(experiment, force)

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -42,8 +42,9 @@ def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.resu
     results_from_repo = list(results_from_repo)
     for repo_result in results_from_repo:
         data = repo_result.data
+        git_hash_msg = ("dirty_" if repo_result.dirty else "") + repo_result.git_hash
         result = {
-            'Git hash': repo_result.git_hash,
+            'Git hash': git_hash_msg,
             'Dataset hash': data['dataset']['hash'][:8],
             'Run start': data['run_start'][:19],
             'Model': data['model_info']['type'],

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     import pypastry
 
 
-def cache_display(results_from_repo: Iterator['pypastry.experiment.results.Result'], git_hash: str) -> None:
-    results_dataframe = _get_results_dataframe(results_from_repo, git_hash=git_hash)
+def cache_display(results_from_repo: Iterator['pypastry.experiment.results.Result']) -> None:
+    results_dataframe = _get_results_dataframe(results_from_repo)
     display = repr(results_dataframe)
 
     try:
@@ -31,7 +31,7 @@ def cache_display(results_from_repo: Iterator['pypastry.experiment.results.Resul
         output_file.write(display)
 
 
-def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.results.Result'], git_hash: str) -> 'DataFrame':
+def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.results.Result']) -> 'DataFrame':
     from pandas import DataFrame, set_option
     set_option('display.max_rows', None)
     set_option('display.max_columns', None)
@@ -40,9 +40,8 @@ def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.resu
     results = []
     for repo_result in results_from_repo:
         data = repo_result.data
-        git_hash_msg = ("dirty_" if repo_result.dirty else "") + git_hash[:8]
         result = {
-            'Git hash': git_hash_msg,
+            'Git hash': data["git_hash"],
             'Dataset hash': data['dataset']['hash'][:8],
             'Run start': data['run_start'][:19],
             'Model': data['model_info']['type'],

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -39,7 +39,6 @@ def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.resu
     set_option('display.max_colwidth', -1)
     results = []
     summaries = []
-    results_from_repo = list(results_from_repo)
     for repo_result in results_from_repo:
         data = repo_result.data
         git_hash_msg = ("dirty_" if repo_result.dirty else "") + repo_result.git_hash

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -41,7 +41,8 @@ def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.resu
     for repo_result in results_from_repo:
         data = repo_result.data
         result = {
-            'Git hash': data["git_hash"],
+            'Git hash': data["git_hash"] if "git_hash" in data else "Unavailable",
+            'Git summary': data["git_summary"] if "git_summary" in data else "Unavailable",
             'Dataset hash': data['dataset']['hash'][:8],
             'Run start': data['run_start'][:19],
             'Model': data['model_info']['type'],

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -59,8 +59,8 @@ class ExperimentRunner:
             'hash': dataset_hash,
             'columns': experiment.dataset.columns.tolist(),
         }
-        git_hash_msg = ("dirty_" if self.git_repo.is_dirty() else "") + self.git_repo.head.object.hexsha
-        _ = self.results_repo.save_results(run_info, dataset_info, git_hash=git_hash_msg)
+        git_hash_msg = ("dirty_" if self.git_repo.is_dirty() else "") + self.git_repo.head.object.hexsha[:8]
+        _ = self.results_repo.save_results(run_info, dataset_info, git_hash_msg=git_hash_msg)
         return estimators
 
 

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -38,12 +38,14 @@ class ExperimentRunner:
         force: bool,
         limit: int = None,
     ):
+
+        last_git_hash = self.git_repo.head.object.hexsha
         print("Got dataset with {} rows".format(len(experiment.dataset)))
         if force or not self.git_repo.is_dirty():
             print("Running evaluation")
             estimators = self._run_evaluation(experiment)
             results = self.results_repo.get_results(self.git_repo)
-            self.results_display.cache_display(results)
+            self.results_display.cache_display(results, git_hash=last_git_hash)
         else:
             raise DirtyRepoError("There are untracked/unstaged/staged changes in git repo, force flag was not given. "
                                  "Please commit your changes or provide force flag - note that in this case "

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -35,8 +35,8 @@ class ExperimentRunner:
     def run_experiment(
         self,
         experiment: Experiment,
-        message: str,
-        force: bool,
+        message: str = "",
+        force: bool = False,
         limit: int = None,
     ):
 
@@ -197,7 +197,7 @@ def _score(scorers: List[_BaseScorer], estimator, X_test, y_test):
     return scores
 
 
-def run_experiment(experiment, message, force=False):
+def run_experiment(experiment, message="", force=False):
     git_repo = Repo(REPO_PATH, search_parent_directories=True)  # type: pypastry.experiment.Experiment
     results_repo = ResultsRepo(RESULTS_PATH)  # type: pypastry.experiment.results.ResultsRepo
     runner = ExperimentRunner(git_repo, results_repo, display)  # type:

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -39,13 +39,12 @@ class ExperimentRunner:
         limit: int = None,
     ):
 
-        last_git_hash = self.git_repo.head.object.hexsha
         print("Got dataset with {} rows".format(len(experiment.dataset)))
         if force or not self.git_repo.is_dirty():
             print("Running evaluation")
             estimators = self._run_evaluation(experiment)
             results = self.results_repo.get_results(self.git_repo)
-            self.results_display.cache_display(results, git_hash=last_git_hash)
+            self.results_display.cache_display(results)
         else:
             raise DirtyRepoError("There are untracked/unstaged/staged changes in git repo, force flag was not given. "
                                  "Please commit your changes or provide force flag - note that in this case "
@@ -60,7 +59,7 @@ class ExperimentRunner:
             'hash': dataset_hash,
             'columns': experiment.dataset.columns.tolist(),
         }
-        _ = self.results_repo.save_results(run_info, dataset_info)
+        _ = self.results_repo.save_results(run_info, dataset_info, git_hash=self.git_repo.head.object.hexsha)
         return estimators
 
 

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -39,7 +39,7 @@ class ExperimentRunner:
         limit: int = None,
     ):
         print("Got dataset with {} rows".format(len(experiment.dataset)))
-        if force or not self.git_repo.is_dirty:
+        if force or not self.git_repo.is_dirty():
             print("Running evaluation")
             estimators = self._run_evaluation(experiment)
             results = self.results_repo.get_results(self.git_repo)

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -59,7 +59,8 @@ class ExperimentRunner:
             'hash': dataset_hash,
             'columns': experiment.dataset.columns.tolist(),
         }
-        _ = self.results_repo.save_results(run_info, dataset_info, git_hash=self.git_repo.head.object.hexsha)
+        git_hash_msg = ("dirty_" if self.git_repo.is_dirty() else "") + self.git_repo.head.object.hexsha
+        _ = self.results_repo.save_results(run_info, dataset_info, git_hash=git_hash_msg)
         return estimators
 
 

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -12,14 +12,15 @@ class ResultsRepo:
     def __init__(self, results_path: str):
         self.results_path = results_path
 
-    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_hash_msg: str) -> List[str]:
+    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_info: Dict[str, str]) -> List[str]:
         try:
             os.mkdir(self.results_path)
         except FileExistsError:
             pass
         new_filenames = []
         run_info['dataset'] = dataset_info
-        run_info['git_hash'] = git_hash_msg
+        run_info['git_hash'] = git_info["git_hash_msg"]
+        run_info['git_summary'] = git_info["git_summary_msg"]
         with NamedTemporaryFile(mode='w', prefix='result-', suffix='.json',
                                 dir=self.results_path, delete=False) as output_file:
             json.dump(run_info, output_file, indent=4, default=str)

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Any, List, NamedTuple
 
-Result = NamedTuple('Result', [('data', Dict[str, Any]), ('git_hash', str), ('summary', str)])
+Result = NamedTuple('Result', [('data', Dict[str, Any]), ('git_hash', str), ('summary', str), ("dirty", bool)])
 
 
 class ResultsRepo:
@@ -32,4 +32,4 @@ class ResultsRepo:
                 summary = git_commit.summary
                 git_hash = git_commit.hexsha[:8]
                 result_json = json.load(results_file)
-                yield Result(result_json, git_hash, summary)
+                yield Result(result_json, git_hash, summary, git_repo.is_dirty())

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -1,10 +1,11 @@
 import json
-from os import mkdir
-from pathlib import Path
+import os
+import glob
 from tempfile import NamedTemporaryFile
 from typing import Dict, Any, List, NamedTuple
 
-Result = NamedTuple('Result', [('data', Dict[str, Any]), ('git_hash', str), ('summary', str), ("dirty", bool)])
+
+Result = NamedTuple('Result', [('data', Dict[str, Any]), ("dirty", bool)])
 
 
 class ResultsRepo:
@@ -13,7 +14,7 @@ class ResultsRepo:
 
     def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any]) -> List[str]:
         try:
-            mkdir(self.results_path)
+            os.mkdir(self.results_path)
         except FileExistsError:
             pass
         new_filenames = []
@@ -26,10 +27,7 @@ class ResultsRepo:
         return new_filenames
 
     def get_results(self, git_repo):
-        for path in Path(self.results_path).glob('*'):
-            with open(str(path)) as results_file:
-                git_commit = next(git_repo.iter_commits(paths=path.absolute()))
-                summary = git_commit.summary
-                git_hash = git_commit.hexsha[:8]
+        for path in glob.glob(os.path.join(self.results_path, "*.json")):
+            with open(str(path), "r") as results_file:
                 result_json = json.load(results_file)
-                yield Result(result_json, git_hash, summary, git_repo.is_dirty())
+            yield Result(result_json, git_repo.is_dirty())

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -12,14 +12,14 @@ class ResultsRepo:
     def __init__(self, results_path: str):
         self.results_path = results_path
 
-    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_hash: str) -> List[str]:
+    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_hash_msg: str) -> List[str]:
         try:
             os.mkdir(self.results_path)
         except FileExistsError:
             pass
         new_filenames = []
         run_info['dataset'] = dataset_info
-        run_info['git_hash'] = git_hash[:8]
+        run_info['git_hash'] = git_hash_msg
         with NamedTemporaryFile(mode='w', prefix='result-', suffix='.json',
                                 dir=self.results_path, delete=False) as output_file:
             json.dump(run_info, output_file, indent=4, default=str)

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -27,7 +27,7 @@ class ResultsRepo:
 
     def get_results(self, git_repo):
         for path in Path(self.results_path).glob('*'):
-            with open(path) as results_file:
+            with open(str(path)) as results_file:
                 git_commit = next(git_repo.iter_commits(paths=path.absolute()))
                 summary = git_commit.summary
                 git_hash = git_commit.hexsha[:8]

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -12,13 +12,14 @@ class ResultsRepo:
     def __init__(self, results_path: str):
         self.results_path = results_path
 
-    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any]) -> List[str]:
+    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_hash: str) -> List[str]:
         try:
             os.mkdir(self.results_path)
         except FileExistsError:
             pass
         new_filenames = []
         run_info['dataset'] = dataset_info
+        run_info['git_hash'] = git_hash[:8]
         with NamedTemporaryFile(mode='w', prefix='result-', suffix='.json',
                                 dir=self.results_path, delete=False) as output_file:
             json.dump(run_info, output_file, indent=4, default=str)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 from setuptools import setup, find_packages
 
 #check to make sure the python version is compatible 
-if sys.version_info < (3, 5):
-    sys.exit('Sorry, PyPastry requires Python version 3.5 or greater')
+if sys.version_info < (3, 6):
+    sys.exit('Sorry, PyPastry requires Python version 3.6 or greater')
 
 # Reading in the ReadMe file as the doc file
 with open("README.md", "r") as fh:
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='pypastry',
-    version='0.0.3',
+    version='0.2.0',
     description='PyPastry machine learning experimentation framework',
     author='Daoud Clarke',
     url='https://github.com/datapastry/pypastry',
@@ -42,7 +42,6 @@ setup(
     include_package_data=True,
     #Minimum requirement of python, licesnse, and operating system. 
     classifiers=[
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/display_test.py
+++ b/tests/display_test.py
@@ -39,7 +39,7 @@ RESULTS = {
 
 def test_get_display():
     result = Result(RESULTS, 'abc123')
-    results_dataframe = _get_results_dataframe([result])
+    results_dataframe = _get_results_dataframe([result], "abc123")
     row = results_dataframe.iloc[0].to_dict()
 
     expected = {

--- a/tests/display_test.py
+++ b/tests/display_test.py
@@ -33,13 +33,13 @@ RESULTS = {
             "input",
             "output"
         ]
-    }
+    },
 }
 
 
 def test_get_display():
     result = Result(RESULTS, 'abc123')
-    results_dataframe = _get_results_dataframe([result], "abc123")
+    results_dataframe = _get_results_dataframe([result])
     row = results_dataframe.iloc[0].to_dict()
 
     expected = {

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -28,10 +28,9 @@ def test_simple_evaluation():
     results_repo_mock.save_results.return_value = new_results_files
     results_display_mock = Mock()
     runner = ExperimentRunner(git_mock, results_repo_mock, results_display_mock)
-    commit_message = "Test commit message"
 
     # When
-    runner.run_experiment(experiment, False, commit_message)
+    runner.run_experiment(experiment, False)
 
     # Then
     call_args_list = results_repo_mock.save_results.call_args_list
@@ -74,7 +73,7 @@ def test_grouped_evaluation():
     results_display_mock = Mock()
     runner = ExperimentRunner(git_mock, results_repo_mock, results_display_mock)
 
-    runner.run_experiment(experiment, False, "Test commit message")
+    runner.run_experiment(experiment, False)
 
     assert 1 == len(results_repo_mock.save_results.call_args_list)
     run_info, dataset_info = results_repo_mock.save_results.call_args[0]

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -31,7 +31,7 @@ def test_simple_evaluation(dirty=False, force=False):
     runner = ExperimentRunner(git_mock, results_repo_mock, results_display_mock)
 
     # When
-    runner.run_experiment(experiment, force)
+    runner.run_experiment(experiment, "", force)
 
     # Then
     call_args_list = results_repo_mock.save_results.call_args_list
@@ -71,7 +71,7 @@ def test_grouped_evaluation():
     results_display_mock = Mock()
     runner = ExperimentRunner(git_mock, results_repo_mock, results_display_mock)
 
-    runner.run_experiment(experiment, False)
+    runner.run_experiment(experiment, "", False)
 
     assert 1 == len(results_repo_mock.save_results.call_args_list)
     run_info, dataset_info = results_repo_mock.save_results.call_args[0]


### PR DESCRIPTION
pypastry 2.0. New behaviour:
 - Pypastry does not `git add` or `git commit` anything for you.
 - By default, pypastry requires your git repo to be clean --> no staged or unstaged changes (untracked changes are fine and are ignored). When experiment is finished, last commit's hash and user's message are stored with evaluation results to a JSON file.
 - You can, however, use **force** flag `-f` (`force` keyword argument in `run_experiment()`) to run the experiment even when your repo is dirty (=not clean). Hash of the last commit (which does **NOT** correspond to the exact state of the code you run anymore) is still saved to result JSON, but with prefix `dirty_`. Note that you cannot retrieve exact state of the code when using dirty repo and `force`.

This changes encourages developer to develop fast with frequent changes in code, while not being worried the code is commited with every experiment run. Also results JSONs are not commited. These changes together make it the commit history clearer.

It's up to developer's responsibility to version the code manually and also manually backup JSONs with results.