### PR TITLE
Dataset size and result JSON filename are stored to result information.

### DIFF
--- a/pypastry/commands/print_.py
+++ b/pypastry/commands/print_.py
@@ -2,6 +2,7 @@ import argparse
 
 from pypastry.display import print_cache_file, cache_display, _get_results_dataframe
 from pypastry.paths import RESULTS_PATH
+from pypastry.experiment.results import ResultsRepo
 
 
 def run():
@@ -24,8 +25,6 @@ def run():
 
 
 def get_results():
-    from pypastry.experiment.results import ResultsRepo
-    from git import Repo
     results_repo = ResultsRepo(RESULTS_PATH)
-    results = results_repo.get_results(Repo('.', search_parent_directories=True))
+    results = results_repo.get_results()
     return results

--- a/pypastry/display.py
+++ b/pypastry/display.py
@@ -42,8 +42,10 @@ def _get_results_dataframe(results_from_repo: Iterator['pypastry.experiment.resu
         data = repo_result.data
         result = {
             'Git hash': data["git_hash"] if "git_hash" in data else "Unavailable",
-            'Git summary': data["git_summary"] if "git_summary" in data else "Unavailable",
+            'Summary': data["git_summary"] if "git_summary" in data else "Unavailable",
             'Dataset hash': data['dataset']['hash'][:8],
+            'Dataset size': data['dataset']['size'] if "size" in data["dataset"] else "Unavailable",
+            'Result JSON name': data['result_json_name'] if "result_json_name" in data else "Unavailable",
             'Run start': data['run_start'][:19],
             'Model': data['model_info']['type'],
             'Duration (s)': "{:.2f}".format(data['run_seconds']),

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -59,12 +59,13 @@ class ExperimentRunner:
         dataset_info = {
             'hash': dataset_hash,
             'columns': experiment.dataset.columns.tolist(),
+            'size': len(experiment.dataset),
         }
         git_info = {
             "git_hash_msg": ("dirty_" if self.git_repo.is_dirty() else "") + self.git_repo.head.object.hexsha[:8],
             "git_summary_msg": message,
         }
-        _ = self.results_repo.save_results(run_info, dataset_info, git_info=git_info)
+        self.results_repo.save_results(run_info, dataset_info, git_info=git_info)
         return estimators
 
 

--- a/pypastry/experiment/evaluation.py
+++ b/pypastry/experiment/evaluation.py
@@ -44,7 +44,7 @@ class ExperimentRunner:
         if force or not self.git_repo.is_dirty():
             print("Running evaluation")
             estimators = self._run_evaluation(experiment, message)
-            results = self.results_repo.get_results(self.git_repo)
+            results = self.results_repo.get_results()
             self.results_display.cache_display(results)
         else:
             raise DirtyRepoError("There are untracked/unstaged/staged changes in git repo, force flag was not given. "

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -3,7 +3,7 @@ import os
 import glob
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict, Any, List, NamedTuple
+from typing import Dict, Any, NamedTuple
 
 
 Result = NamedTuple('Result', [('data', Dict[str, Any]), ("dirty", bool)])
@@ -12,7 +12,6 @@ Result = NamedTuple('Result', [('data', Dict[str, Any]), ("dirty", bool)])
 class ResultsRepo:
     def __init__(self, results_path: str):
         self.results_path = results_path
-        self.result_files = []
 
     def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_info: Dict[str, str]):
         try:
@@ -27,10 +26,9 @@ class ResultsRepo:
             run_info["result_json_name"] = Path(output_file.name).name
             json.dump(run_info, output_file, indent=4, default=str)
             output_file.flush()
-        self.result_files.append(output_file.name)
 
     def get_results(self, git_repo):
-        for path in sorted(glob.glob(os.path.join(self.results_path, "*.json")), key=os.path.getmtime):
+        for path in glob.glob(os.path.join(self.results_path, "*.json")):
             with open(str(path), "r") as results_file:
                 result_json = json.load(results_file)
             yield Result(result_json, git_repo.is_dirty())

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -1,6 +1,7 @@
 import json
 import os
 import glob
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Any, List, NamedTuple
 
@@ -11,25 +12,25 @@ Result = NamedTuple('Result', [('data', Dict[str, Any]), ("dirty", bool)])
 class ResultsRepo:
     def __init__(self, results_path: str):
         self.results_path = results_path
+        self.result_files = []
 
-    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_info: Dict[str, str]) -> List[str]:
+    def save_results(self, run_info: Dict[str, Any], dataset_info: Dict[str, Any], git_info: Dict[str, str]):
         try:
             os.mkdir(self.results_path)
         except FileExistsError:
             pass
-        new_filenames = []
         run_info['dataset'] = dataset_info
         run_info['git_hash'] = git_info["git_hash_msg"]
         run_info['git_summary'] = git_info["git_summary_msg"]
         with NamedTemporaryFile(mode='w', prefix='result-', suffix='.json',
                                 dir=self.results_path, delete=False) as output_file:
+            run_info["result_json_name"] = Path(output_file.name).name
             json.dump(run_info, output_file, indent=4, default=str)
             output_file.flush()
-        new_filenames.append(output_file.name)
-        return new_filenames
+        self.result_files.append(output_file.name)
 
     def get_results(self, git_repo):
-        for path in glob.glob(os.path.join(self.results_path, "*.json")):
+        for path in sorted(glob.glob(os.path.join(self.results_path, "*.json")), key=os.path.getmtime):
             with open(str(path), "r") as results_file:
                 result_json = json.load(results_file)
             yield Result(result_json, git_repo.is_dirty())

--- a/pypastry/experiment/results.py
+++ b/pypastry/experiment/results.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 from typing import Dict, Any, NamedTuple
 
 
-Result = NamedTuple('Result', [('data', Dict[str, Any]), ("dirty", bool)])
+Result = NamedTuple('Result', [('data', Dict[str, Any])])
 
 
 class ResultsRepo:
@@ -27,8 +27,8 @@ class ResultsRepo:
             json.dump(run_info, output_file, indent=4, default=str)
             output_file.flush()
 
-    def get_results(self, git_repo):
+    def get_results(self):
         for path in glob.glob(os.path.join(self.results_path, "*.json")):
             with open(str(path), "r") as results_file:
                 result_json = json.load(results_file)
-            yield Result(result_json, git_repo.is_dirty())
+            yield Result(result_json)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='pypastry',
-    version='0.2.0',
+    version='0.2.1',
     description='PyPastry machine learning experimentation framework',
     author='Daoud Clarke',
     url='https://github.com/datapastry/pypastry',

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -25,8 +25,6 @@ def test_simple_evaluation(dirty=False, force=False):
     git_mock = Mock()
     git_mock.is_dirty.return_value = dirty
     results_repo_mock = Mock()
-    new_results_files = ['results/abc.json']
-    results_repo_mock.save_results.return_value = new_results_files
     results_display_mock = Mock()
     runner = ExperimentRunner(git_mock, results_repo_mock, results_display_mock)
 


### PR DESCRIPTION
- New items among results in `run_info` dict and summary dataframe:
  - dataset size
  - result JSON filename
- "Git summary" column renamed to "Summary" (keys in dicts still keep their "git_" prefix to ensure backward compatibility)
- Minor code cleanup